### PR TITLE
Use zero address fallback instead of public client

### DIFF
--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -8,9 +8,7 @@
 	import mintDia from '$lib/images/mint-dia.svg';
 	import ftso from '$lib/images/ftso.svg';
 	import Button from '$lib/components/Button.svelte';
-	import {
-		simulateErc20PriceOracleReceiptVaultPreviewDeposit
-	} from '../../generated';
+	import { simulateErc20PriceOracleReceiptVaultPreviewDeposit } from '../../generated';
 	import { signerAddress, wagmiConfig, web3Modal } from 'svelte-wagmi';
 	import { onDestroy, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
@@ -47,10 +45,10 @@
 
 	const getPriceRatio = async () => {
 		const { result } = await simulateErc20PriceOracleReceiptVaultPreviewDeposit($wagmiConfig, {
-				address: $cysFlareAddress,
-				args: [BigInt(1e18), 0n],
-				account: ZeroAddress as `0x${string}`
-			})
+			address: $cysFlareAddress,
+			args: [BigInt(1e18), 0n],
+			account: ZeroAddress as `0x${string}`
+		});
 		priceRatio = result;
 	};
 

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -45,7 +45,7 @@
 
 	const getPriceRatio = async () => {
 		const { result } = await simulateErc20PriceOracleReceiptVaultPreviewDeposit($wagmiConfig, {
-			address: $cysFlareAddress,
+			address: $cysFlrAddress,
 			args: [BigInt(1e18), 0n],
 			account: ZeroAddress as `0x${string}`
 		});

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Card from '$lib/components/Card.svelte';
-	import transactionStore, { ADDRESS_ZERO } from '$lib/transactionStore';
+	import transactionStore from '$lib/transactionStore';
 	import balancesStore from '$lib/balancesStore';
 	import Input from '$lib/components/Input.svelte';
 	import { cysFlareAddress, stakedFlareAddress } from '$lib/stores';

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -9,7 +9,6 @@
 	import ftso from '$lib/images/ftso.svg';
 	import Button from '$lib/components/Button.svelte';
 	import {
-		erc20PriceOracleReceiptVaultAbi,
 		simulateErc20PriceOracleReceiptVaultPreviewDeposit
 	} from '../../generated';
 	import { signerAddress, wagmiConfig, web3Modal } from 'svelte-wagmi';
@@ -49,12 +48,9 @@
 	const getPriceRatio = async () => {
 		const { result } = await simulateErc20PriceOracleReceiptVaultPreviewDeposit($wagmiConfig, {
 				address: $cysFlareAddress,
-				abi: erc20PriceOracleReceiptVaultAbi,
-				functionName: 'previewDeposit',
 				args: [BigInt(1e18), 0n],
-				account: ZeroAddress
+				account: ZeroAddress as `0x${string}`
 			})
-		console.log(result)
 		priceRatio = result;
 	};
 

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Card from '$lib/components/Card.svelte';
-	import transactionStore from '$lib/transactionStore';
+	import transactionStore, { ADDRESS_ZERO } from '$lib/transactionStore';
 	import balancesStore from '$lib/balancesStore';
 	import Input from '$lib/components/Input.svelte';
 	import { cysFlareAddress, stakedFlareAddress } from '$lib/stores';
@@ -8,7 +8,6 @@
 	import mintDia from '$lib/images/mint-dia.svg';
 	import ftso from '$lib/images/ftso.svg';
 	import Button from '$lib/components/Button.svelte';
-
 	import {
 		erc20PriceOracleReceiptVaultAbi,
 		simulateErc20PriceOracleReceiptVaultPreviewDeposit
@@ -17,13 +16,7 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import { formatEther, parseEther } from 'ethers';
-	import { createPublicClient, http } from 'viem';
-	import { flare } from 'viem/chains';
-
-	const publicClient = createPublicClient({
-		chain: flare,
-		transport: http()
-	});
+	import { ZeroAddress } from 'ethers';
 
 	export let amountToLock = '0.0';
 
@@ -54,20 +47,14 @@
 	};
 
 	const getPriceRatio = async () => {
-		let result;
-		if ($signerAddress) {
-			({ result } = await simulateErc20PriceOracleReceiptVaultPreviewDeposit($wagmiConfig, {
-				address: $cysFlareAddress,
-				args: [BigInt(1e18), 0n]
-			}));
-		} else {
-			({ result } = await publicClient.simulateContract({
+		const { result } = await simulateErc20PriceOracleReceiptVaultPreviewDeposit($wagmiConfig, {
 				address: $cysFlareAddress,
 				abi: erc20PriceOracleReceiptVaultAbi,
 				functionName: 'previewDeposit',
-				args: [BigInt(1e18), 0n]
-			}));
-		}
+				args: [BigInt(1e18), 0n],
+				account: ZeroAddress
+			})
+		console.log(result)
 		priceRatio = result;
 	};
 

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -29,20 +29,6 @@ vi.mock('$lib/transactionStore', async (importOriginal) => ({
 	}
 }));
 
-const mockSimulateContract = vi.fn().mockResolvedValue({
-	result: 14920000000000000n
-});
-
-vi.mock('viem', async (importOriginal) => {
-	const actual = await importOriginal();
-	return {
-		...(actual as object),
-		createPublicClient: vi.fn(() => ({
-			simulateContract: mockSimulateContract
-		}))
-	};
-});
-
 describe('Lock Component', () => {
 	const initiateLockTransactionSpy = vi.spyOn(transactionStore, 'initiateLockTransaction');
 
@@ -97,17 +83,8 @@ describe('Lock Component', () => {
 	it('should disable the lock button if SFLR balance is insufficient', async () => {
 		mockBalancesStore.mockSetSubscribeValue(BigInt(0), BigInt(0), 'Ready');
 		render(Lock);
-
 		const lockButton = screen.getByTestId('lock-button');
 		expect(lockButton).toBeDisabled();
-	});
-
-	it('should call publicClient.simulateContract if there is no signerAddress', async () => {
-		mockSignerAddressStore.mockSetSubscribeValue('');
-		render(Lock);
-		await waitFor(() => {
-			expect(mockSimulateContract).toHaveBeenCalled();
-		});
 	});
 
 	it('should show the connect message if there is no signerAddress', async () => {


### PR DESCRIPTION
- Specifying an address property running a generated function will use that as a fallback if none exists in the connector, meaning we can simulate without needing to use viem's publicClient