### PR TITLE
Replace reminaing uses of wflr/cyflr

### DIFF
--- a/src/lib/balancesStore.test.ts
+++ b/src/lib/balancesStore.test.ts
@@ -47,8 +47,8 @@ describe('cysFlrBalanceStore', () => {
 	});
 
 	it('should refresh cysFLRBalance correctly', async () => {
-		const mockCyFlrBalance = BigInt(2000);
-		(readErc20BalanceOf as Mock).mockResolvedValue(mockCyFlrBalance);
+		const mockCysFlrBalance = BigInt(2000);
+		(readErc20BalanceOf as Mock).mockResolvedValue(mockCysFlrBalance);
 
 		await refreshcysFlr(
 			mockWagmiConfigStore as unknown as Config,
@@ -57,7 +57,7 @@ describe('cysFlrBalanceStore', () => {
 		);
 
 		const storeValue = get(cysFlrBalanceStore);
-		expect(storeValue.cysFLRBalance).toBe(mockCyFlrBalance);
+		expect(storeValue.cysFLRBalance).toBe(mockCysFlrBalance);
 		expect(storeValue.status).toBe('Ready');
 	});
 

--- a/src/lib/balancesStore.test.ts
+++ b/src/lib/balancesStore.test.ts
@@ -32,8 +32,8 @@ describe('cysFlrBalanceStore', () => {
 	});
 
 	it('should refresh sFlrBalance correctly', async () => {
-		const mockWFlrBalance = BigInt(1000);
-		(readErc20BalanceOf as Mock).mockResolvedValue(mockWFlrBalance);
+		const mocksFlrBalance = BigInt(1000);
+		(readErc20BalanceOf as Mock).mockResolvedValue(mocksFlrBalance);
 
 		await refreshsFlr(
 			mockWagmiConfigStore as unknown as Config,
@@ -42,7 +42,7 @@ describe('cysFlrBalanceStore', () => {
 		);
 
 		const storeValue = get(cysFlrBalanceStore);
-		expect(storeValue.sFlrBalance).toBe(mockWFlrBalance);
+		expect(storeValue.sFlrBalance).toBe(mocksFlrBalance);
 		expect(storeValue.status).toBe('Ready');
 	});
 
@@ -62,8 +62,8 @@ describe('cysFlrBalanceStore', () => {
 	});
 
 	it('should reset the store to its initial state', () => {
-		const mockWFlrBalance = BigInt(1000);
-		(readErc20BalanceOf as Mock).mockResolvedValue(mockWFlrBalance);
+		const mocksFlrBalance = BigInt(1000);
+		(readErc20BalanceOf as Mock).mockResolvedValue(mocksFlrBalance);
 		refreshsFlr(mockWagmiConfigStore as unknown as Config, mocksFlrAddress, mockSignerAddress);
 
 		reset();

--- a/src/lib/balancesStore.ts
+++ b/src/lib/balancesStore.ts
@@ -44,7 +44,7 @@ const cysFLRBalanceStore = () => {
 		signerAddress: string
 	) => {
 		try {
-			const [newSFlrBalance, newCyFlrBalance] = await Promise.all([
+			const [newSFlrBalance, newCysFlrBalance] = await Promise.all([
 				readErc20BalanceOf(config, {
 					address: sFlrAddress,
 					args: [signerAddress as Hex]
@@ -58,7 +58,7 @@ const cysFLRBalanceStore = () => {
 			update((state) => ({
 				...state,
 				sFlrBalance: newSFlrBalance,
-				cyFlrBalance: newCyFlrBalance,
+				cysFlrBalance: newCysFlrBalance,
 				status: 'Ready'
 			}));
 		} catch (error) {

--- a/src/lib/components/Footer.test.ts
+++ b/src/lib/components/Footer.test.ts
@@ -18,7 +18,7 @@ describe('Footer.svelte', () => {
 		vi.spyOn(global, 'fetch').mockResolvedValue({} as Response);
 	});
 
-	it('should display cyFLR and sFLR supplies correctly when fetched', async () => {
+	it('should display cysFLR and sFLR supplies correctly when fetched', async () => {
 		(readErc20TotalSupply as Mock)
 			.mockResolvedValueOnce(BigInt(2000000000000000000))
 			.mockResolvedValueOnce(BigInt(5000000000000000000));
@@ -42,7 +42,7 @@ describe('Footer.svelte', () => {
 		render(Footer);
 
 		await waitFor(() => {
-			expect(screen.queryByText('Total cyFLR supply')).not.toBeInTheDocument();
+			expect(screen.queryByText('Total cysFLR supply')).not.toBeInTheDocument();
 			expect(screen.queryByText('Total sFLR supply')).not.toBeInTheDocument();
 		});
 	});

--- a/src/lib/components/Lock.svelte
+++ b/src/lib/components/Lock.svelte
@@ -205,7 +205,7 @@
 				class="flex w-full items-center justify-center gap-2 text-center text-lg font-semibold text-white md:text-2xl"
 			>
 				{#key priceRatio}
-					<span in:fade={{ duration: 700 }} data-testid="calculated-cyflr"
+					<span in:fade={{ duration: 700 }} data-testid="calculated-cysflr"
 						>{(+amountToLock * Number(formatEther(priceRatio.toString()))).toFixed(3)}</span
 					>
 				{/key}

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -50,7 +50,7 @@ describe('Lock Component', () => {
 		initiateLockTransactionSpy.mockClear();
 		mockBalancesStore.mockSetSubscribeValue(
 			BigInt(1234000000000000000), // sFlrBalance
-			BigInt(9876000000000000000), // wFlrBalance
+			BigInt(9876000000000000000), // cysFlrBalance
 			'Ready' // status
 		);
 	});

--- a/src/lib/components/Lock.test.ts
+++ b/src/lib/components/Lock.test.ts
@@ -75,8 +75,8 @@ describe('Lock Component', () => {
 		await waitFor(() => {
 			const priceRatio = screen.getByTestId('price-ratio');
 			expect(priceRatio).toBeInTheDocument();
-			const calculatedCyflr = screen.getByTestId('calculated-cyflr');
-			expect(calculatedCyflr).toHaveTextContent('0.001');
+			const calculatedCysflr = screen.getByTestId('calculated-cysflr');
+			expect(calculatedCysflr).toHaveTextContent('0.001');
 		});
 	});
 

--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -11,7 +11,7 @@
 
 	enum ButtonStatus {
 		INSUFFICIENT_RECEIPTS = 'INSUFFICIENT RECEIPTS',
-		INSUFFICIENT_cyFLR = 'INSUFFICIENT cyFLR',
+		INSUFFICIENT_cysFLR = 'INSUFFICIENT cysFLR',
 		READY = 'UNLOCK'
 	}
 	export let receipt: Receipt;
@@ -42,7 +42,7 @@
 		if (erc1155balance < amountToRedeem) {
 			buttonStatus = ButtonStatus.INSUFFICIENT_RECEIPTS;
 		} else if ($balancesStore.cysFLRBalance < amountToRedeem) {
-			buttonStatus = ButtonStatus.INSUFFICIENT_cyFLR;
+			buttonStatus = ButtonStatus.INSUFFICIENT_cysFLR;
 		} else {
 			buttonStatus = ButtonStatus.READY;
 		}

--- a/src/lib/components/ReceiptModal.test.ts
+++ b/src/lib/components/ReceiptModal.test.ts
@@ -7,11 +7,11 @@ import { formatEther } from 'ethers';
 import { mockReceipt } from '$lib/mocks/mockReceipt';
 import userEvent from '@testing-library/user-event';
 
-const { mockBalancesStore, mockErc1155AddressStore, mockCyFlrAddressStore, mockSflrAddressStore } =
+const { mockBalancesStore, mockErc1155AddressStore, mockCysFlrAddressStore, mockSflrAddressStore } =
 	await vi.hoisted(() => import('$lib/mocks/mockStores'));
 
 vi.mock('$lib/stores', async () => ({
-	cysFlrAddress: mockCyFlrAddressStore,
+	cysFlrAddress: mockCysFlrAddressStore,
 	erc1155Address: mockErc1155AddressStore,
 	sFlrAddress: mockSflrAddressStore
 }));
@@ -67,7 +67,7 @@ describe('ReceiptModal Component', () => {
 		});
 	});
 
-	it('should display "INSUFFICIENT cyFLR" if cyFLR balance is insufficient', async () => {
+	it('should display "INSUFFICIENT cysFLR" if cysFLR balance is insufficient', async () => {
 		mockBalancesStore.mockSetSubscribeValue(BigInt(0), BigInt(0), 'Ready');
 
 		render(ReceiptModal, { receipt: mockReceipt });
@@ -78,7 +78,7 @@ describe('ReceiptModal Component', () => {
 
 		await waitFor(() => {
 			const button = screen.getByTestId('unlock-button');
-			expect(button).toHaveTextContent('INSUFFICIENT cyFLR');
+			expect(button).toHaveTextContent('INSUFFICIENT cysFLR');
 			expect(button).toBeDisabled();
 		});
 	});

--- a/src/lib/components/ReceiptsTable.svelte
+++ b/src/lib/components/ReceiptsTable.svelte
@@ -55,10 +55,10 @@
 					{Number(formatEther(receipt.balance)).toFixed(5)}
 				</TableBodyCell>
 
-				<TableBodyCell class="hidden md:table-cell" data-testid={`wflr-per-receipt-${index}`}>
+				<TableBodyCell class="hidden md:table-cell" data-testid={`sflr-per-receipt-${index}`}>
 					{receipt.readableFlrPerReceipt}
 				</TableBodyCell>
-				<TableBodyCell class="" data-testid={`total-locked-wflr-${index}`}>
+				<TableBodyCell class="" data-testid={`total-locked-sflr-${index}`}>
 					{receipt.readableTotalFlr}
 				</TableBodyCell>
 				<TableBodyCell class="">

--- a/src/lib/components/ReceiptsTable.test.ts
+++ b/src/lib/components/ReceiptsTable.test.ts
@@ -20,10 +20,10 @@ describe('ReceiptsTable Component', () => {
 			expect(screen.getByTestId(`number-held-${i}`)).toHaveTextContent(
 				Number(formatEther(mockReceipts[i].balance)).toFixed(5)
 			);
-			expect(screen.getByTestId(`wflr-per-receipt-${i}`)).toHaveTextContent(
+			expect(screen.getByTestId(`sflr-per-receipt-${i}`)).toHaveTextContent(
 				Number(mockReceipts[i].readableFlrPerReceipt).toFixed(5)
 			);
-			expect(screen.getByTestId(`total-locked-wflr-${i}`)).toHaveTextContent(
+			expect(screen.getByTestId(`total-locked-sflr-${i}`)).toHaveTextContent(
 				Number(mockReceipts[i].readableTotalFlr).toFixed(5)
 			);
 		}

--- a/src/lib/components/TransactionModal.test.ts
+++ b/src/lib/components/TransactionModal.test.ts
@@ -90,24 +90,24 @@ describe('TransactionModal Component', () => {
 	it('should handle multiple statuses like CHECKING_ALLOWANCE and PENDING_APPROVAL', async () => {
 		mockTransactionStore.mockSetSubscribeValue({
 			status: TransactionStatus.CHECKING_ALLOWANCE,
-			message: 'Checking your approved wFLR spend...'
+			message: 'Checking your approved SFLR spend...'
 		});
 
 		render(TransactionModal);
 
 		await waitFor(() => {
 			expect(screen.getByTestId('pending-message')).toHaveTextContent(
-				'Checking your approved wFLR spend...'
+				'Checking your approved SFLR spend...'
 			);
 		});
 
 		mockTransactionStore.mockSetSubscribeValue({
 			status: TransactionStatus.PENDING_APPROVAL,
-			message: 'Approving WFLR spend...'
+			message: 'Approving SFLR spend...'
 		});
 
 		await waitFor(() => {
-			expect(screen.getByTestId('pending-message')).toHaveTextContent('Approving WFLR spend...');
+			expect(screen.getByTestId('pending-message')).toHaveTextContent('Approving SFLR spend...');
 		});
 	});
 });

--- a/src/lib/mocks/mockStores.ts
+++ b/src/lib/mocks/mockStores.ts
@@ -13,7 +13,7 @@ const mockPageWritable = writable({ url: { pathname: '/' } });
 const mockConnectedWritable = writable<boolean>(false);
 const mockWagmiConfigWritable = writable<Config>(mockWeb3Config);
 const erc1155AddressWritable = writable<Hex>('0x6D6111ab02800aC64f66456874add77F44529a90');
-const mockCyFlrAddressWritable = writable<Hex>('0x91e3B9820b47c7D4e6765E90F94C1638E7bc53C6');
+const mockCysFlrAddressWritable = writable<Hex>('0x91e3B9820b47c7D4e6765E90F94C1638E7bc53C6');
 const mockSFlrAddressWritable = writable<Hex>('0x91e3B9820b47c7D4e6765E90F94C163123456789');
 const mockBalancesWritable = writable({
 	cysFLRBalance: BigInt(100),
@@ -74,10 +74,10 @@ export const mockErc1155AddressStore = {
 	mockSetSubscribeValue: (value: Hex): void => erc1155AddressWritable.set(value)
 };
 
-export const mockCyFlrAddressStore = {
-	subscribe: mockCyFlrAddressWritable.subscribe,
-	set: mockCyFlrAddressWritable.set,
-	mockSetSubscribeValue: (value: Hex): void => mockCyFlrAddressWritable.set(value)
+export const mockCysFlrAddressStore = {
+	subscribe: mockCysFlrAddressWritable.subscribe,
+	set: mockCysFlrAddressWritable.set,
+	mockSetSubscribeValue: (value: Hex): void => mockCysFlrAddressWritable.set(value)
 };
 
 export const mockSflrAddressStore = {

--- a/src/lib/transactionStore.test.ts
+++ b/src/lib/transactionStore.test.ts
@@ -138,7 +138,7 @@ describe('transactionStore', () => {
 		});
 	});
 
-	it('should prompt the user to approve cyFLR contract to lock SFLR if allowance is less than assets', async () => {
+	it('should prompt the user to approve cysFLR contract to lock SFLR if allowance is less than assets', async () => {
 		const mockAllowance = BigInt(500);
 
 		(readErc20Allowance as Mock).mockResolvedValueOnce(mockAllowance);

--- a/src/lib/transactionStore.test.ts
+++ b/src/lib/transactionStore.test.ts
@@ -138,7 +138,7 @@ describe('transactionStore', () => {
 		});
 	});
 
-	it('should prompt the user to approve cyFLR contract to lock WFLR if allowance is less than assets', async () => {
+	it('should prompt the user to approve cyFLR contract to lock SFLR if allowance is less than assets', async () => {
 		const mockAllowance = BigInt(500);
 
 		(readErc20Allowance as Mock).mockResolvedValueOnce(mockAllowance);


### PR DESCRIPTION
This pull request primarily focuses on renaming variables and identifiers related to `cyFLR` to `cysFLR` across multiple files for consistency. Additionally, there are a few changes to the test descriptions and mock data to reflect these updates.

Key changes include:

### Variable Renaming:

* Renamed `mockWFlrBalance` to `mocksFlrBalance` and `mockCyFlrBalance` to `mockCysFlrBalance` in `balancesStore.test.ts`. [[1]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL35-R36) [[2]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL45-R51) [[3]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL60-R66)
* Updated `newCyFlrBalance` to `newCysFlrBalance` in `balancesStore.ts`. [[1]](diffhunk://#diff-d512e55e0332cf3e851a2251427dd9c3f543acdb6535f07f69162f63aa06fcdeL47-R47) [[2]](diffhunk://#diff-d512e55e0332cf3e851a2251427dd9c3f543acdb6535f07f69162f63aa06fcdeL61-R61)
* Changed `mockCyFlrAddressStore` to `mockCysFlrAddressStore` in `mockStores.ts`. [[1]](diffhunk://#diff-ecda2871802acc72110133bbcaa0bed335d3a5f76272fbb31d25361662ca1ea3L10-R14) [[2]](diffhunk://#diff-98a87d222b08b28475d61dbabd920d8514d098d206078954031b7c7e1df03b4eL16-R16) [[3]](diffhunk://#diff-98a87d222b08b28475d61dbabd920d8514d098d206078954031b7c7e1df03b4eL77-R80)

### Test Descriptions:

* Updated test descriptions to reflect the renaming from `cyFLR` to `cysFLR` in `Footer.test.ts`, `Lock.test.ts`, `ReceiptModal.test.ts`, `ReceiptsTable.test.ts`, and `TransactionModal.test.ts`. [[1]](diffhunk://#diff-fd37995e4d10df2e290c38633c629fdcb6152563d6bb599d4daded9448771afeL21-R21) [[2]](diffhunk://#diff-fd37995e4d10df2e290c38633c629fdcb6152563d6bb599d4daded9448771afeL45-R45) [[3]](diffhunk://#diff-c69fdf162e76896f4a9dea0674b0b4cf5e572fe962d1ffd6377b5ea2adc3d331L39-R39) [[4]](diffhunk://#diff-c69fdf162e76896f4a9dea0674b0b4cf5e572fe962d1ffd6377b5ea2adc3d331L64-R65) [[5]](diffhunk://#diff-ecda2871802acc72110133bbcaa0bed335d3a5f76272fbb31d25361662ca1ea3L70-R70) [[6]](diffhunk://#diff-ecda2871802acc72110133bbcaa0bed335d3a5f76272fbb31d25361662ca1ea3L81-R81) [[7]](diffhunk://#diff-69508e64c5852f5428eea1dfc5b07dee3429b4d15a30795aa54cc3c59eaa1db2L23-R26) [[8]](diffhunk://#diff-d2943576c7a99d155cf12a26ad75a3a8f16da5024dae21cc8096fbce83225923L93-R110) [[9]](diffhunk://#diff-3c1013afec22fd0b7c0596eaa69082818a6e72aaec3e1e0ae473e0addbc96842L141-R141)

### Component Updates:

* Adjusted data-test IDs and text content to use `cysFLR` instead of `cyFLR` in `Lock.svelte`, `ReceiptModal.svelte`, `ReceiptsTable.svelte`, and `TransactionModal.test.ts`. [[1]](diffhunk://#diff-398c308534fcd53dff33843fc46c58a6010ff7e92a103eaebb2269f2f26cf1ceL187-R187) [[2]](diffhunk://#diff-934e6cc5578191cf1898fd494fe70bb2dbd01e76d4da96564cff09682cb5a3f7L14-R14) [[3]](diffhunk://#diff-934e6cc5578191cf1898fd494fe70bb2dbd01e76d4da96564cff09682cb5a3f7L45-R45) [[4]](diffhunk://#diff-f261cd4a7547617fc7cbb638a8d6909c4fd02438a3f7f9b09cbf068ffb37da89L58-R61) [[5]](diffhunk://#diff-d2943576c7a99d155cf12a26ad75a3a8f16da5024dae21cc8096fbce83225923L93-R110)