### PR TITLE
Simplify balances stores

### DIFF
--- a/src/lib/balancesStore.test.ts
+++ b/src/lib/balancesStore.test.ts
@@ -66,7 +66,12 @@ describe('cysFlrBalanceStore', () => {
 	it('should reset the store to its initial state', () => {
 		const mockWFlrBalance = BigInt(1000);
 		(readErc20BalanceOf as Mock).mockResolvedValue(mockWFlrBalance);
-		refreshBalances(mockWagmiConfigStore as unknown as Config, mocksFlrAddress, mockCysFlrAddress, mockSignerAddress);
+		refreshBalances(
+			mockWagmiConfigStore as unknown as Config,
+			mocksFlrAddress,
+			mockCysFlrAddress,
+			mockSignerAddress
+		);
 
 		reset();
 

--- a/src/lib/balancesStore.test.ts
+++ b/src/lib/balancesStore.test.ts
@@ -16,7 +16,7 @@ describe('cysFlrBalanceStore', () => {
 	const mocksFlrAddress = '0xabcdef1234567890';
 	const mockCysFlrAddress = '0xabcdefabcdef1234';
 
-	const { reset, refreshcysFlr, refreshsFlr } = balancesStore;
+	const { reset, refreshBalances } = balancesStore;
 
 	beforeEach(() => {
 		vi.resetAllMocks();
@@ -25,7 +25,7 @@ describe('cysFlrBalanceStore', () => {
 
 	it('should initialize with the correct default state', () => {
 		expect(get(cysFlrBalanceStore)).toEqual({
-			cysFLRBalance: BigInt(0),
+			cysFlrBalance: BigInt(0),
 			sFlrBalance: BigInt(0),
 			status: 'Checking'
 		});
@@ -35,9 +35,10 @@ describe('cysFlrBalanceStore', () => {
 		const mockWFlrBalance = BigInt(1000);
 		(readErc20BalanceOf as Mock).mockResolvedValue(mockWFlrBalance);
 
-		await refreshsFlr(
+		await refreshBalances(
 			mockWagmiConfigStore as unknown as Config,
 			mocksFlrAddress,
+			mockCysFlrAddress,
 			mockSignerAddress
 		);
 
@@ -46,30 +47,31 @@ describe('cysFlrBalanceStore', () => {
 		expect(storeValue.status).toBe('Ready');
 	});
 
-	it('should refresh cysFLRBalance correctly', async () => {
+	it('should refresh cysFlrBalance correctly', async () => {
 		const mockCyFlrBalance = BigInt(2000);
 		(readErc20BalanceOf as Mock).mockResolvedValue(mockCyFlrBalance);
 
-		await refreshcysFlr(
+		await refreshBalances(
 			mockWagmiConfigStore as unknown as Config,
+			mocksFlrAddress,
 			mockCysFlrAddress,
 			mockSignerAddress
 		);
 
 		const storeValue = get(cysFlrBalanceStore);
-		expect(storeValue.cysFLRBalance).toBe(mockCyFlrBalance);
+		expect(storeValue.cysFlrBalance).toBe(mockCyFlrBalance);
 		expect(storeValue.status).toBe('Ready');
 	});
 
 	it('should reset the store to its initial state', () => {
 		const mockWFlrBalance = BigInt(1000);
 		(readErc20BalanceOf as Mock).mockResolvedValue(mockWFlrBalance);
-		refreshsFlr(mockWagmiConfigStore as unknown as Config, mocksFlrAddress, mockSignerAddress);
+		refreshBalances(mockWagmiConfigStore as unknown as Config, mocksFlrAddress, mockCysFlrAddress, mockSignerAddress);
 
 		reset();
 
 		expect(get(cysFlrBalanceStore)).toEqual({
-			cysFLRBalance: BigInt(0),
+			cysFlrBalance: BigInt(0),
 			sFlrBalance: BigInt(0),
 			status: 'Checking'
 		});

--- a/src/lib/balancesStore.ts
+++ b/src/lib/balancesStore.ts
@@ -4,47 +4,24 @@ import { writable } from 'svelte/store';
 import type { Hex } from 'viem';
 
 const initialState = {
-	cysFLRBalance: BigInt(0),
+	cysFlrBalance: BigInt(0),
 	sFlrBalance: BigInt(0),
 	status: 'Checking'
 };
 
-const cysFLRBalanceStore = () => {
+const balancesStore = () => {
 	const { subscribe, set, update } = writable(initialState);
 	const reset = () => set(initialState);
 
-	const refreshsFlr = async (config: Config, sFlrAddress: Hex, signerAddress: string) => {
-		const newSflrBalance = await readErc20BalanceOf(config, {
-			address: sFlrAddress,
-			args: [signerAddress as Hex]
-		});
-		update((state) => ({
-			...state,
-			sFlrBalance: newSflrBalance,
-			status: 'Ready'
-		}));
-	};
 
-	const refreshcysFlr = async (config: Config, cysFLRAddress: Hex, signerAddress: string) => {
-		const newcysFLRBalance = await readErc20BalanceOf(config, {
-			address: cysFLRAddress,
-			args: [signerAddress as Hex]
-		});
-		update((state) => ({
-			...state,
-			cysFLRBalance: newcysFLRBalance,
-			status: 'Ready'
-		}));
-	};
-
-	const refreshBothBalances = async (
+	const refreshBalances = async (
 		config: Config,
 		sFlrAddress: Hex,
 		cysFlrAddress: Hex,
 		signerAddress: string
 	) => {
 		try {
-			const [newSFlrBalance, newCyFlrBalance] = await Promise.all([
+			const [newSFlrBalance, newCysFlrBalance] = await Promise.all([
 				readErc20BalanceOf(config, {
 					address: sFlrAddress,
 					args: [signerAddress as Hex]
@@ -58,7 +35,7 @@ const cysFLRBalanceStore = () => {
 			update((state) => ({
 				...state,
 				sFlrBalance: newSFlrBalance,
-				cyFlrBalance: newCyFlrBalance,
+				cysFlrBalance: newCysFlrBalance,
 				status: 'Ready'
 			}));
 		} catch (error) {
@@ -73,10 +50,8 @@ const cysFLRBalanceStore = () => {
 	return {
 		subscribe,
 		reset,
-		refreshcysFlr,
-		refreshsFlr,
-		refreshBothBalances
+		refreshBalances
 	};
 };
 
-export default cysFLRBalanceStore();
+export default balancesStore();

--- a/src/lib/balancesStore.ts
+++ b/src/lib/balancesStore.ts
@@ -13,7 +13,6 @@ const balancesStore = () => {
 	const { subscribe, set, update } = writable(initialState);
 	const reset = () => set(initialState);
 
-
 	const refreshBalances = async (
 		config: Config,
 		sFlrAddress: Hex,

--- a/src/lib/components/ReceiptModal.svelte
+++ b/src/lib/components/ReceiptModal.svelte
@@ -36,12 +36,12 @@
 	}
 
 	$: maxRedeemable =
-		$balancesStore?.cysFLRBalance < erc1155balance ? $balancesStore.cysFLRBalance : erc1155balance;
+		$balancesStore?.cysFlrBalance < erc1155balance ? $balancesStore.cysFlrBalance : erc1155balance;
 
 	$: if (amountToRedeem) {
 		if (erc1155balance < amountToRedeem) {
 			buttonStatus = ButtonStatus.INSUFFICIENT_RECEIPTS;
-		} else if ($balancesStore.cysFLRBalance < amountToRedeem) {
+		} else if ($balancesStore.cysFlrBalance < amountToRedeem) {
 			buttonStatus = ButtonStatus.INSUFFICIENT_cyFLR;
 		} else {
 			buttonStatus = ButtonStatus.READY;

--- a/src/lib/components/Unlock.svelte
+++ b/src/lib/components/Unlock.svelte
@@ -14,8 +14,6 @@
 
 	let loading = true;
 
-	$: console.log($balancesStore)
-
 	$: if ($signerAddress) {
 		refreshReceipts();
 	}

--- a/src/lib/components/Unlock.svelte
+++ b/src/lib/components/Unlock.svelte
@@ -14,6 +14,8 @@
 
 	let loading = true;
 
+	$: console.log($balancesStore)
+
 	$: if ($signerAddress) {
 		refreshReceipts();
 	}
@@ -42,8 +44,8 @@
 			>
 				<span>BALANCE</span>
 				<div class="flex flex-row gap-4">
-					{#key $balancesStore.cysFLRBalance}<span in:fade={{ duration: 700 }}
-							>{Number(formatEther($balancesStore.cysFLRBalance)).toFixed(4)}</span
+					{#key $balancesStore.cysFlrBalance}<span in:fade={{ duration: 700 }}
+							>{Number(formatEther($balancesStore.cysFlrBalance)).toFixed(4)}</span
 						>{/key}
 					<span>cysFLR</span>
 				</div>

--- a/src/lib/mocks/mockStores.ts
+++ b/src/lib/mocks/mockStores.ts
@@ -16,7 +16,7 @@ const erc1155AddressWritable = writable<Hex>('0x6D6111ab02800aC64f66456874add77F
 const mockCyFlrAddressWritable = writable<Hex>('0x91e3B9820b47c7D4e6765E90F94C1638E7bc53C6');
 const mockSFlrAddressWritable = writable<Hex>('0x91e3B9820b47c7D4e6765E90F94C163123456789');
 const mockBalancesWritable = writable({
-	cysFLRBalance: BigInt(100),
+	cysFlrBalance: BigInt(100),
 	sFlrBalance: BigInt(100),
 	status: 'Checking'
 });
@@ -24,9 +24,9 @@ const mockBalancesWritable = writable({
 export const mockBalancesStore = {
 	subscribe: mockBalancesWritable.subscribe,
 	set: mockBalancesWritable.set,
-	mockSetSubscribeValue: (cysFLRBalance: bigint, sFlrBalance: bigint, status: string): void => {
+	mockSetSubscribeValue: (cysFlrBalance: bigint, sFlrBalance: bigint, status: string): void => {
 		mockBalancesWritable.set({
-			cysFLRBalance,
+			cysFlrBalance,
 			sFlrBalance,
 			status
 		});

--- a/src/lib/transactionStore.ts
+++ b/src/lib/transactionStore.ts
@@ -145,7 +145,7 @@ const transactionStore = () => {
 					awaitLockTx(hash);
 					const res = await waitForTransactionReceipt(config, { hash: hash });
 					if (res) {
-						await balancesStore.refreshBothBalances(
+						await balancesStore.refreshBalances(
 							config,
 							sFlrAddress,
 							cysFlrAddress,
@@ -176,7 +176,7 @@ const transactionStore = () => {
 				awaitLockTx(hash);
 				const res = await waitForTransactionReceipt(config, { confirmations: 4, hash: hash });
 				if (res) {
-					await balancesStore.refreshBothBalances(
+					await balancesStore.refreshBalances(
 						config,
 						sFlrAddress,
 						cysFlrAddress,
@@ -216,7 +216,7 @@ const transactionStore = () => {
 				awaitUnlockTx(hash);
 				const res = await waitForTransactionReceipt(config, { confirmations: 4, hash: hash });
 				if (res) {
-					await balancesStore.refreshBothBalances(
+					await balancesStore.refreshBalances(
 						config,
 						sFlrAddress,
 						cysFlrAddress,

--- a/src/routes/(actions)/+layout.svelte
+++ b/src/routes/(actions)/+layout.svelte
@@ -10,7 +10,7 @@
 	import { base } from '$app/paths';
 
 	$: if ($signerAddress) {
-		balancesStore.refreshBothBalances($wagmiConfig, $sFlrAddress, $cysFlrAddress, $signerAddress);
+		balancesStore.refreshBalances($wagmiConfig, $sFlrAddress, $cysFlrAddress, $signerAddress);
 	}
 </script>
 


### PR DESCRIPTION
This pull request includes several changes to the balance store and its related components to improve consistency and functionality. The main updates involve renaming variables and functions for clarity, consolidating balance refresh functions, and updating affected components and tests accordingly.

### Renaming and Consolidation:

* Renamed `cysFLRBalance` to `cysFlrBalance` in `src/lib/balancesStore.ts` and related files for consistency. [[1]](diffhunk://#diff-d512e55e0332cf3e851a2251427dd9c3f543acdb6535f07f69162f63aa06fcdeL7-R24) [[2]](diffhunk://#diff-98a87d222b08b28475d61dbabd920d8514d098d206078954031b7c7e1df03b4eL19-R29)
* Consolidated `refreshcysFlr` and `refreshsFlr` functions into a single `refreshBalances` function in `src/lib/balancesStore.ts`. [[1]](diffhunk://#diff-d512e55e0332cf3e851a2251427dd9c3f543acdb6535f07f69162f63aa06fcdeL7-R24) [[2]](diffhunk://#diff-d512e55e0332cf3e851a2251427dd9c3f543acdb6535f07f69162f63aa06fcdeL76-R57)

### Test Updates:

* Updated test cases in `src/lib/balancesStore.test.ts` to reflect the renaming and consolidation of balance refresh functions. [[1]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL19-R19) [[2]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL28-R28) [[3]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL38-R41) [[4]](diffhunk://#diff-c3363bd3c0f13750e90808f4be7ca7f9a2adc1518229fba63379a0cb163f6c2fL49-R74)

### Component Updates:

* Updated `ReceiptModal.svelte` and `Unlock.svelte` components to use the new `cysFlrBalance` variable name. [[1]](diffhunk://#diff-934e6cc5578191cf1898fd494fe70bb2dbd01e76d4da96564cff09682cb5a3f7L39-R44) [[2]](diffhunk://#diff-e30940750ef68388c58a3d0c4ca2457c8251c1a1f5541e6b453f00fad6f87d86L45-R48)
* Added a console log for debugging purposes in `Unlock.svelte`.

### Store Usage Updates:

* Updated the usage of the balance refresh function in `transactionStore.ts` to use `refreshBalances`. [[1]](diffhunk://#diff-68e48bf0f2e4b4c6abc216e6b33f70109a42764d836fa8bc87cb5a38be43d922L148-R148) [[2]](diffhunk://#diff-68e48bf0f2e4b4c6abc216e6b33f70109a42764d836fa8bc87cb5a38be43d922L179-R179) [[3]](diffhunk://#diff-68e48bf0f2e4b4c6abc216e6b33f70109a42764d836fa8bc87cb5a38be43d922L219-R219)
* Updated the layout script in `+layout.svelte` to use the consolidated `refreshBalances` function.